### PR TITLE
Remove wandb login and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ python scripts/modify_checkpoints.py
 ```
 
 ### Training REFace
-To train a new model on CelebAHQ, you can use `main.py`. For example,
+Before starting training, set your Weights & Biases API key in the
+`WANDB_API_KEY` environment variable. Then you can train a new model on
+CelebAHQ using `main.py`. For example,
 ```
 python -u main.py \
 --logdir models/REFace/ \

--- a/main.py
+++ b/main.py
@@ -22,7 +22,6 @@ from ldm.util import instantiate_from_config
 import socket
 from pytorch_lightning.plugins.environments import ClusterEnvironment,SLURMEnvironment
 import wandb
-wandb.login(key="fa0767adc156a87ed43a394680774f3116fc3ed2")
 
 def get_parser(**parser_kwargs):
     def str2bool(v):


### PR DESCRIPTION
## Summary
- remove hardcoded `wandb.login` call
- mention setting `WANDB_API_KEY` before training

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'PIL', 'imp')*

------
https://chatgpt.com/codex/tasks/task_b_6886cabefff48329a0dd008a8e36dcbc